### PR TITLE
Platform/O6: define BT/WL_RADIO_DISABLE_L gpios in the ACPI table

### DIFF
--- a/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Iomux.asl
+++ b/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Iomux.asl
@@ -793,5 +793,23 @@ Device (MUX1) {
         {
             SKY1_IOMUXC_SFI_GPIO0,
         }
+
+    PinGroup ("wl_radio_disable_l", ResourceProducer, ,
+        RawDataBuffer ()
+        {
+            0x00, 0x90, 0x00, 0xD4,
+        })
+        {
+            SKY1_IOMUXC_SFI_GPIO4,
+        }
+
+    PinGroup ("bt_radio_disable_l", ResourceProducer, ,
+        RawDataBuffer ()
+        {
+            0x00, 0x94, 0x00, 0xD4,
+        })
+        {
+            SKY1_IOMUXC_SFI_GPIO5,
+        }
   })
 }

--- a/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Ssdt.asl
+++ b/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Ssdt.asl
@@ -25,5 +25,6 @@ DefinitionBlock("SsdtTable.aml", "SSDT", 2, "RADXA", "ORIONO6", 1) {
     include("EfiRtc.asl")
     include("CdnsPciePwr.asl")
     include("HardwareMonitor.asl")
+    include("Wireless.asl")
   }
 }

--- a/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Wireless.asl
+++ b/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Wireless.asl
@@ -1,0 +1,61 @@
+/** @file
+
+  Copyright 2024 Cix Technology Group Co., Ltd. All Rights Reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Gpio.h"
+
+Device (VWL0) {
+  Name (_HID, "PRP0001")
+  Name (_UID, 0x23)
+  Name (_STA, 0x0B)
+
+  Name (_CRS, ResourceTemplate () {
+    PinGroupFunction(Exclusive, 0x0, "\\_SB.MUX1", 0, "wl_radio_disable_l", ResourceConsumer,)
+    GpioIo (Exclusive, PullNone, 0, 0, IoRestrictionOutputOnly,
+    "\\_SB.GPI5", 0, ResourceConsumer) { 4 }  // GPIO019
+  })
+
+  Name (_DSD, Package () {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+    Package () {
+      Package () { "compatible", "regulator-fixed" },
+      Package () { "regulator-name", "wl_radio_disable_l" },
+      Package () { "regulator-min-microvolt", 1800000 },
+      Package () { "regulator-max-microvolt", 1800000 },
+      Package () { "gpio", Package () { ^VWL0, 0, 0, GPIO_ACTIVE_HIGH } },
+      Package () { "enable-active-high", 1 },
+      Package () { "regulator-always-on", 1 },
+      Package () { "off-on-delay-us", 15000 },
+    },
+  })
+}
+
+Device (VBT0) {
+  Name (_HID, "PRP0001")
+  Name (_UID, 0x24)
+  Name (_STA, 0x0B)
+
+  Name (_CRS, ResourceTemplate () {
+    PinGroupFunction(Exclusive, 0x0, "\\_SB.MUX1", 0, "bt_radio_disable_l", ResourceConsumer,)
+    GpioIo (Exclusive, PullNone, 0, 0, IoRestrictionOutputOnly,
+    "\\_SB.GPI5", 0, ResourceConsumer) { 5 }  // GPIO020
+  })
+
+  Name (_DSD, Package () {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+    Package () {
+      Package () { "compatible", "regulator-fixed" },
+      Package () { "regulator-name", "bt_radio_disable_l" },
+      Package () { "regulator-min-microvolt", 1800000 },
+      Package () { "regulator-max-microvolt", 1800000 },
+      Package () { "gpio", Package () { ^VBT0, 0, 0, GPIO_ACTIVE_HIGH } },
+      Package () { "enable-active-high", 1 },
+      Package () { "regulator-always-on", 1 },
+      Package () { "off-on-delay-us", 15000 },
+    },
+  })
+}


### PR DESCRIPTION
    Platform/O6: define BT/WL_RADIO_DISABLE_L gpios in the ACPI table
    
    The issue is that OS doesn't control the GPIOs unless they are defined
    in the ACPI table.
    
    This change defines the GPIO pins of WL_RADIO_DISABLE_L (GPIO019) and
    BT_RADIO_DISABLE_L (GPIO020)[0]. It's found that when a WLAN/BT module
    is attached to the PCIe E Key port, pulling up the GPIO020 and GPIO019
    will disable the functions of WiFi and Bluetooth; therefore, we should
    ensure they are pulled up to enable the functions.
    
    The command `gpioinfo` should contain the following information after
    this change:
    ```
    "GPIO019" "PRP0001:0d"  output  active-high [used bias-disabled]
    "GPIO020" "PRP0001:0e"  output  active-high [used bias-disabled]
    ```
    
    This change is based on this commit[1].
    
    [0]: https://dl.radxa.com/orion/o6/hw/radxa_orion_o6_v1.20_schematic.pdf
    [1]: https://github.com/radxa/edk2-platforms/commit/7e61f64a334dc5b5f8383c90445a569e0801ccb0
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>