### PR TITLE
Platform/O6: define usb power gpios in ACPI table

### DIFF
--- a/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Iomux.asl
+++ b/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Iomux.asl
@@ -622,9 +622,11 @@ Device (MUX1) {
         RawDataBuffer ()
         {
             0x00, 0xd4, 0x00, 0x44,
+            0x00, 0xe4, 0x00, 0x24,
         })
         {
             SKY1_IOMUXC_USB_OC6_L,
+            SKY1_IOMUXC_DRIVE_VBUS0,
         }
     PinGroup ("pinctrl_usb1", ResourceProducer, ,
         RawDataBuffer ()
@@ -654,7 +656,7 @@ Device (MUX1) {
         RawDataBuffer ()
         {
             0x00, 0xcc, 0x00, 0x44,
-            0x00, 0xe8, 0x00, 0xa4,
+            0x00, 0xe8, 0x00, 0x24,
         })
         {
             SKY1_IOMUXC_USB_OC4_L,
@@ -664,7 +666,7 @@ Device (MUX1) {
         RawDataBuffer ()
         {
             0x00, 0xd0, 0x00, 0x44,
-            0x00, 0xec, 0x00, 0xa4,
+            0x00, 0xec, 0x00, 0x24,
         })
         {
             SKY1_IOMUXC_USB_OC5_L,

--- a/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Ssdt.asl
+++ b/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/Ssdt.asl
@@ -26,5 +26,6 @@ DefinitionBlock("SsdtTable.aml", "SSDT", 2, "RADXA", "ORIONO6", 1) {
     include("CdnsPciePwr.asl")
     include("HardwareMonitor.asl")
     include("Wireless.asl")
+    include("UsbPwr.asl")
   }
 }

--- a/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/UsbPwr.asl
+++ b/Platform/Radxa/Orion/O6/Drivers/AcpiPlatfomTables/UsbPwr.asl
@@ -1,0 +1,90 @@
+/** @file
+
+  Copyright 2024 Cix Technology Group Co., Ltd. All Rights Reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Gpio.h"
+
+Device (VUS0) {
+  Name (_HID, "PRP0001")
+  Name (_UID, 0x25)
+  Name (_STA, 0x0B)
+
+  Name (_CRS, ResourceTemplate () {
+    PinGroupFunction(Exclusive, 0x0, "\\_SB.MUX1", 0, "usb_drive_vbus0", ResourceConsumer,)
+    GpioIo (Exclusive, PullNone, 0, 0, IoRestrictionOutputOnly,
+    "\\_SB.GPI4", 0, ResourceConsumer) { 29 } // GPIO040
+  })
+
+  Name (_DSD, Package () {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+    Package () {
+      Package () { "compatible", "regulator-fixed" },
+      Package () { "regulator-name", "vdd_usb_drive_vbus0" },
+      Package () { "regulator-min-microvolt", 5000000 },
+      Package () { "regulator-max-microvolt", 5000000 },
+      Package () { "gpio", Package () { ^VUS0, 0, 0, GPIO_ACTIVE_HIGH } },
+      Package () { "regulator-always-on", 1 },
+      Package () { "regulator-pull-down", 1 },
+      Package () { "enable-active-high", 1 },
+      Package () { "off-on-delay-us", 15000 },
+    }
+  })
+}
+
+Device (VUS4) {
+  Name (_HID, "PRP0001")
+  Name (_UID, 0x26)
+  Name (_STA, 0x0B)
+
+  Name (_CRS, ResourceTemplate () {
+    PinGroupFunction(Exclusive, 0x0, "\\_SB.MUX1", 0, "usb_drive_vbus4", ResourceConsumer,)
+    GpioIo (Exclusive, PullNone, 0, 0, IoRestrictionOutputOnly,
+    "\\_SB.GPI4", 0, ResourceConsumer) { 30 } // GPIO041
+  })
+
+  Name (_DSD, Package () {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+    Package () {
+      Package () { "compatible", "regulator-fixed" },
+      Package () { "regulator-name", "vdd_usb_drive_vbus4" },
+      Package () { "regulator-min-microvolt", 5000000 },
+      Package () { "regulator-max-microvolt", 5000000 },
+      Package () { "gpio", Package () { ^VUS4, 0, 0, GPIO_ACTIVE_HIGH } },
+      Package () { "regulator-always-on", 1 },
+      Package () { "regulator-pull-down", 1 },
+      Package () { "enable-active-high", 1 },
+      Package () { "off-on-delay-us", 15000 },
+    }
+  })
+}
+
+Device (VUS5) {
+  Name (_HID, "PRP0001")
+  Name (_UID, 0x27)
+  Name (_STA, 0x0B)
+
+  Name (_CRS, ResourceTemplate () {
+    PinGroupFunction(Exclusive, 0x0, "\\_SB.MUX1", 0, "usb_drive_vbus5", ResourceConsumer,)
+    GpioIo (Exclusive, PullNone, 0, 0, IoRestrictionOutputOnly,
+    "\\_SB.GPI4", 0, ResourceConsumer) { 31 } // GPIO042
+  })
+
+  Name (_DSD, Package () {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+    Package () {
+      Package () { "compatible", "regulator-fixed" },
+      Package () { "regulator-name", "vdd_usb_drive_vbus5" },
+      Package () { "regulator-min-microvolt", 5000000 },
+      Package () { "regulator-max-microvolt", 5000000 },
+      Package () { "gpio", Package () { ^VUS5, 0, 0, GPIO_ACTIVE_HIGH } },
+      Package () { "regulator-always-on", 1 },
+      Package () { "regulator-pull-down", 1 },
+      Package () { "enable-active-high", 1 },
+      Package () { "off-on-delay-us", 15000 },
+    }
+  })
+}


### PR DESCRIPTION
    Platform/O6: define usb power gpios in ACPI table
    
    This change defines USB_DRIVE_VBUS0 (GPIO040), USB_DRIVE_VBUS4 (GPIO041)
    and USB_DRIVE_VBUS5 (GPIO042) in the ACPI table. The `_HID` is defined
    as `PRP0001` so the DT-compatible device identification,
    `regulator-fixed`, will be applied[0]. For the definition of `_STA`,
    please check[1]. The USB power GPIOs are expected to always be pulled
    up[2].
    
    The following information is expected to be provided by the `gpioinfo`
    command after this change is applied:
    ```
    "GPIO040" "PRP0001:0d"  output  active-high [used bias-disabled]
    "GPIO041" "PRP0001:0e"  output  active-high [used bias-disabled]
    "GPIO042" "PRP0001:0f"  output  active-high [used bias-disabled]
    ```
    
    This change is based on this file[3].
    
    [0]: https://www.kernel.org/doc/html/v6.18/firmware-guide/acpi/enumeration.html#device-tree-namespace-link-device-id
    [1]: https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/06_Device_Configuration/Device_Configuration.html#sta-device-status
    [2]: https://dl.radxa.com/orion/o6/hw/radxa_orion_o6_v1.20_schematic.pdf
    [3]: https://github.com/radxa/edk2-platforms/blob/ca0218b75bb031549198e2679fb626801915cfbe/Platform/Radxa/Orion/O6N/Drivers/AcpiPlatfomTables/UsbPwr.asl
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>