### PR TITLE
Platform/Radxa: Configure default value for DtAcpiPref.Pref

### DIFF
--- a/Platform/Radxa/Platforms/CIX/Sky1/Drivers/PlatformConfigDxe/ComplianceMenu/ComplianceConfig.hfr
+++ b/Platform/Radxa/Platforms/CIX/Sky1/Drivers/PlatformConfigDxe/ComplianceMenu/ComplianceConfig.hfr
@@ -22,7 +22,8 @@ form formid = COMPLIANCE_CONFIG_FORM_ID,
   checkbox varid = DtAcpiPref.Pref,
     prompt = STRING_TOKEN(STR_COMPLIANCE_ACPI),
     help   = STRING_TOKEN(STR_COMPLIANCE_ACPI_HELP),
-    flags  = RESET_REQUIRED,
+    flags  = CHECKBOX_DEFAULT | RESET_REQUIRED,
+    default = TRUE,
   endcheckbox;
 
 suppressif ideqval DtAcpiPref.Pref == DT_ACPI_SELECT_DT;


### PR DESCRIPTION
This PR fixes radxa-pkg/edk2-cix#19 .

A default value for `DtAcpiPref.Pref` is explicitly configured so the action `F9=Reset to Defaults` won't disable ACPI.

This change is based on the chapter `2.11.6.5.1 VFR CheckBox Statement Definition` from this link[0].

[0]: https://tianocore-docs.github.io/edk2-VfrSpecification/draft/2_vfr_description_in_bnf/211_vfr_form_definition.html#211-vfr-form-definition