### PR TITLE
DPTSW-23173: Add reg-io-width property for SCMI shmem

### DIFF
--- a/Platform/CIX/Sky1/Drivers/AcpiSocTables/Dsdt-ScmiMailbox.asl
+++ b/Platform/CIX/Sky1/Drivers/AcpiSocTables/Dsdt-ScmiMailbox.asl
@@ -109,6 +109,7 @@ Device (SHM0) {
     ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
     Package () {
         Package () {"compatible", "arm,scmi-shmem"},
+        Package () { "reg-io-width", 4 },
     }
   })
 }
@@ -127,6 +128,7 @@ Device (SHM1) {
     ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
     Package () {
         Package () {"compatible", "arm,scmi-shmem"},
+        Package () { "reg-io-width", 4 },
     }
   })
 }


### PR DESCRIPTION
Mainline linux has supported 32-bit shared memory access width since v6.13 via property reg-io-width: https://github.com/torvalds/linux/commit/2cd7f3db25feeb7c204e36df9f1bb13bea3a3a20. Adding this property in firmware can avoid hacks in kernel.

Mainline devicetree has already included this property.