### PR TITLE
DPTSW-23172: Revert "DPTSW-15442: arm_scmi: Fix a kernel panic while creating scmi device"

### DIFF
--- a/Platform/CIX/Sky1/Drivers/AcpiSocTables/Dsdt-ScmiMailbox.asl
+++ b/Platform/CIX/Sky1/Drivers/AcpiSocTables/Dsdt-ScmiMailbox.asl
@@ -150,7 +150,7 @@ Device (SCMI) {
   Device (DVFS) {
     Name (_HID, "CIXHA008")
     Name (_UID, 0x0)
-    Name (_STA, 0x0)
+    Name (_STA, 0xB)
 
     Name (_DSD, Package () {
       ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
@@ -162,7 +162,7 @@ Device (SCMI) {
   Device (CLKS) {
     Name (_HID, "CIXHA009")
     Name (_UID, 0x0)
-    Name (_STA, 0x0)
+    Name (_STA, 0xB)
 
     Name (_DSD, Package () {
       ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),


### PR DESCRIPTION
SCMI protocol nodes were disabled to fix a kernel panic issue, while this makes mainline kernel hard to creare SCMI protocol devices in normal way. After fixing the issue in kernel: https://github.com/radxa/kernel/pull/528, we can re-enable SCMI protocol nodes in ACPI now.